### PR TITLE
Resolve build error with react-scripts build

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-tinymce",
   "version": "0.6.0",
   "description": "React TinyMCE component",
-  "main": "lib/main.js",
+  "main": "dist/react-tinymce.min.js",
   "scripts": {
     "test": "node_modules/.bin/rackt test --single-run --browsers Firefox",
     "start": "node_modules/.bin/rackt server"


### PR DESCRIPTION
The `react-scripts build` output error on file `lib/helps/uuid.js`. I have to point the entry file to the minified version for it to work.

I am not sure if this is the correct way to fix the issue, but I am opening a pull request and hopefully we can get it solved the right way. 